### PR TITLE
fix: Fix tensor dimension mismatch in user value weights

### DIFF
--- a/src/two_tower_base_retrieval.py
+++ b/src/two_tower_base_retrieval.py
@@ -316,7 +316,10 @@ class TwoTowerBaseRetrieval(nn.Module):
         # This label is either 1 or 0 depending on whether the user engaged
         # with this item when recommended. Then the net_user_value is 1 when
         # the user has engaged with the item and 0 otherwise.
-        net_user_value = torch.matmul(labels, self.user_value_weights)  # [B]
+
+        # Reshape labels and weights for proper broadcasting
+        # labels is [B, T] and we want to multiply with weights [T]
+        net_user_value = torch.sum(labels * self.user_value_weights, dim=-1)  # [B]
 
         # Optionally debias the net_user_value by the part explained purely
         # by position. Not implemented in this version. Hence net_user_value


### PR DESCRIPTION
# Fix matrix multiplication dimension mismatch in compute_training_loss

## Issue
```
 File "/home/pranav/two_tower_models/src/two_tower_base_retrieval.py", line 319, in compute_training_loss
    net_user_value = torch.matmul(labels, self.user_value_weights)  # [B]
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: inconsistent tensor size, expected tensor [32] and src [1] to have the same number of elements, but got 32 and 1 elements respectively
```

The training was failing due to a dimension mismatch while computing `net_user_value` in the `compute_training_loss` method. The `torch.matmul` between labels [B] and user_value_weights [1], led to a dimension mismatch error.

## Changes
- Modified the computation of `net_user_value` to use element-wise multiplication and sum reduction
- Changed from `torch.matmul(labels, self.user_value_weights)` to `torch.sum(labels * self.user_value_weights, dim=-1)`
- This handles the case where labels is [B, T] and user_value_weights is [T] correctly